### PR TITLE
Fix margin computation device handling

### DIFF
--- a/compute_pt_margins.py
+++ b/compute_pt_margins.py
@@ -109,7 +109,11 @@ def main():
     print(" running model {} with {} workers".format(model_name, args.workers))
 
     data_loader = get_data_loader(
-        data_path=data_path, device=device, batch_size=64, num_workers=args.workers, pin_memory=pin_memory
+        data_path=data_path,
+        device=device,
+        batch_size=batch_size,
+        num_workers=args.workers,
+        pin_memory=pin_memory,
     )
 
 

--- a/scripts/margin_dist_tools.py
+++ b/scripts/margin_dist_tools.py
@@ -41,7 +41,7 @@ def get_margin_distribution(model,X,y,margin_length=4):
 
     num_class = output.shape[1]
     # get list relating to each batch
-    rr = torch.arange(64).to('cuda:0') # Hardcoded to be on cuda device #Will need to be updated asap
+    rr = torch.arange(batch_size, device=X.device)
 
     # get indexes max values for batch
     max_val = torch.argmax(output,dim=1)


### PR DESCRIPTION
## Summary
- support variable batch sizes and devices when computing margins
- use configured batch size in loader

## Testing
- `python -m py_compile compute_pt_margins.py scripts/margin_dist_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_68410d4e79a4832ca90a48648a601107